### PR TITLE
Fix default values

### DIFF
--- a/beacon/values.yaml
+++ b/beacon/values.yaml
@@ -10,10 +10,9 @@ containerArgs:
 
 config:
   datadir: ./data
-  p2p-host-ip: 
   p2p-tcp-port: 13000
   log-file: /data/beacon.log
-  verbosity:
+  verbosity: info
 
 storage:
   capacity: "20Gi"


### PR DESCRIPTION
- Leave it up to the user to specify `p2p-host-ip` (if they like)
- Configure default log level to `info`

Having `p2p-host-ip` as empty in the default values file makes beacon-node crash if the user doesn't specify it in the values file of their chart release. I think it's safe to remove it and leave it up to them to decide if they want to use that argument.
Same would apply to log level, if the argument is not specified and default is used, beacon-node will complain about null value argument. Safe to have info as default.